### PR TITLE
Create CONTRIBUTING file with GH PAT info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to `litr`
+
+## Github API Rate Limiting
+
+Knitting `create-litr.Rmd` makes quite a few calls to the GitHub API and it is easy to quickly reach the GitHub rate limit knitting `create-litr.Rmd` repeatedly in a short period of time. To increase your GitHub API rate limit
+- Use `usethis::create_github_token()` to create a Personal Access Token.
+- Use `usethis::edit_r_environ()` and add the token as `GITHUB_PAT`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,3 +43,5 @@ devtools::check("litr", document = FALSE)
 ```
 
 The `document = FALSE` prevents `devtools` from running its version of `document()` internally, which would overwrite the modifications that `litr::document()` has made.
+
+For more notes on contributing to `litr`, please see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ devtools::check("litr", document = FALSE)
 The `document = FALSE` prevents `devtools` from running its version of
 `document()` internally, which would overwrite the modifications that
 `litr::document()` has made.
+
+For more notes on contributing to `litr`, please see
+[CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
This PR adds a contributing file that explains how potential contributors can add a GitHub PAT to avoid rate limiting when knitting `create-litr.Rmd` as described in #39. I propose we use this file instead of including it in the README since this issue only applies to a specific subset of litr users. Finally, we can also put information on the steps needed to debug litr or other common steps needed when developing for litr.