### PR TITLE
Add better formatting for chunk references

### DIFF
--- a/create-litr.Rmd
+++ b/create-litr.Rmd
@@ -1222,11 +1222,49 @@ add_chunk_label_hyperlinks <- function(html_files,
           )
       }
     )
-
-    writeLines(txt, con = html_files[i])
+    
+    parsed_html <- xml2::read_html(paste(txt,collapse="\n"))
+    span_nodes <- xml2::xml_find_all(parsed_html, ".//span[contains(., '###')]")
+    for(j in seq_along(span_nodes)){
+      span_node <- span_nodes[[j]]
+      span_id <- xml2::xml_attr(span_node, "id")
+      span_node_path <- stringr::str_split(xml2::xml_path(span_node),"/")
+      pre_path <- paste(span_node_path[[1]][1:(length(span_node_path[[1]])-2)],collapse="/")
+      pre_parent <- xml2::xml_find_first(parsed_html, pre_path)
+      # add parent nodes to pre_parent
+      xml2::xml_add_parent(pre_parent,xml2::read_xml('<div class="custom-field"> </div>'))
+      outer_div <- xml2::xml_parent(pre_parent)
+      xml2::xml_add_child(outer_div, xml2::read_xml(stringr::str_glue('<h1><span id="{span_id}">###&quot;{span_id}&quot;###</span></h1>')),.where = 0)
+      xml2::xml_add_parent(pre_parent,xml2::read_xml('<div> </div>'))
+      # remove span with id in comment form last
+      xml2::xml_remove(span_node)
+      # remove the extra line break that is left over from removing the span
+      code_node <- xml2::xml_child(pre_parent)
+      changed_txt <- stringr::str_remove(paste(as.character(xml2::xml_contents(code_node)),collapse=""), "\n")
+      xml2::xml_replace(code_node, xml2::read_xml(stringr::str_glue('<code>{changed_txt}</code>')))
+    }
+    
+    # last thing is to insert an additional style node in the head with our CSS
+    css_string <- ".custom-field {border: 4px solid;border-top: none;padding: 8px;}
+.custom-field h1 {font: 16px normal;margin: -16px -8px 0;font-family:inherit;font-weight:500;line-height:1.1;color:inherit}
+.custom-field h1 span {float: left;}
+.custom-field h1:before {border-top: 4px solid;content: ' ';float: left;margin: 8px 2px 0 -1px;width: 12px;}
+.custom-field h1:after {border-top: 4px solid;content: ' ';display: block;height: 24px;left: 2px;margin: 0 1px 0 0;overflow: hidden;position: relative;top: 8px;}"
+    head_node <- xml2::xml_find_first(parsed_html, ".//head")
+    xml2::xml_add_child(head_node, xml2::read_xml(stringr::str_glue("<style type='text/css'>{css_string}</style>")))
+    txt <- xml2::write_html(parsed_html, html_files[i])
   }
 }
 ```
+
+```{r}
+format_reference_labels <- function(html_files){
+  for(i in seq_along(html_files)){
+    parsed_html <- xml2::read_html(html_files[i])
+  }
+}
+```
+
 
 Finally, we want to replace the ANSI escape sequences used by packages such as `testthat` and `devtools` with their HTML equivalents so the output matches what we see in the terminal.
 


### PR DESCRIPTION
This PR is meant to address #41. It adds functionality to `add_chunk_label_hyperlinks` for formatting referenced chunks by adding a border around the code chunks. We have a working prototype, but it requires some additional polish.

Remaining to-dos:

- [ ] Add `xml2` dependency to `create-litr.Rmd`
- [ ] Add written explanation of what this code does
- [ ] Find fix for edge case where the new line between anchor tags is removed at some point, potentially by `xml2`: 
![image](https://user-images.githubusercontent.com/938890/216794075-f4d6060a-db2b-4a87-b83d-94c694b421fd.png) This might be fixed by finding a better way to remove the new line at the top of each code chunk that results from us removing the span tag that was previously inside the code chunk.
- [ ] Increase margin of box around code chunks so there is more space between it and the next element: 
![image](https://user-images.githubusercontent.com/938890/216794139-eba10014-ca82-4a0a-92f5-c3125ce7a212.png)
- [ ] Decide how we want to format the chunk labels. Remove the `##` delimiter?
